### PR TITLE
double point floating precision aversion

### DIFF
--- a/R/CakeMapInts.R
+++ b/R/CakeMapInts.R
@@ -3,7 +3,7 @@
 source("R/functions.R") # functions for spatial microsimulation, inc. int_trs
 
 ints <- unlist(apply(weights, 2, int_trs)) # generate integerised result
-ints_df <- data.frame(id = ints, zone = rep(1:nrow(cons), colSums(weights)))
+ints_df <- data.frame(id = ints, zone = rep(1:nrow(cons), round(colSums(weights))))
 ind$id <- 1:nrow(ind) # assign each individual an id
 
 # Create spatial microdata, by joining the ids with associated attributes


### PR DESCRIPTION
This is the line that was giving me grief.. Turns out that 
- rep() coerces the second argument into an integer vector...
and that
- as.integer() truncates towards zero if the values being coerced are not integers.

Because colSums (on two of my machines) did not sum to an integer, and hence got rounded down a notch each time, zone and id were differing lengths. 

The rest compiled fine ;)
