### PR TITLE
Change to prevent package loading messages in validation chapter

### DIFF
--- a/validation.Rmd
+++ b/validation.Rmd
@@ -4,7 +4,7 @@ layout: default
 bibliography: bibliography.bib
 ---
 
-```{r, echo=FALSE, results='hide'}
+```{r, echo=FALSE, results='hide', message=FALSE, warning=FALSE}
 load("cache-CakeMap.RData")
 map_pack <- c("ggmap", "rgdal", "maptools", "rgeos", "dplyr", "tidyr", "gridExtra")
 lapply(map_pack, library, character.only = T)


### PR DESCRIPTION
Added message=FALSE and warning=FALSE to R chunk at the beginning of validation chapter to prevent the package loading messages appearing before the start of the validation chapter.